### PR TITLE
Add endpoint to update OpenAI API key for users

### DIFF
--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -54,3 +54,12 @@ async def update_user_query_limit_data(
         mapping={"query_limits": query_limits, "last_query_reset": last_query_reset},
     )
     return True
+
+
+async def update_user_openai_key(db: Redis, username: str, openai_api_key: str) -> bool:
+    """Updates the OpenAI API key for a user in Redis."""
+    user_key = f"user:{username}"
+    if not await db.exists(user_key):
+        return False  # User not found
+    await db.hset(user_key, mapping={"OPENAI_API_KEY": openai_api_key})
+    return True

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,3 +1,5 @@
+import logging
+
 from pydantic import EmailStr
 from redis.asyncio import Redis
 
@@ -6,6 +8,7 @@ from app.utils.security import get_password_hash
 
 # Key for the Redis set storing all registered emails
 EMAIL_SET_KEY = "registered_emails"
+logger = logging.getLogger(__name__)
 
 
 async def get_user_by_username(db: Redis, username: str) -> UserInDB | None:
@@ -38,6 +41,7 @@ async def create_user(db: Redis, user: UserCreate) -> UserInDB:
     await db.hset(f"user:{user.username}", mapping=user_data)
     # Add the email to the set for quick existence checks
     await db.sadd(EMAIL_SET_KEY, user.email)
+    logger.info(f"User {user.username} created successfully.")
     # Return the created user data, ensuring id is set
     return UserInDB(id=user.username, **user_data)
 
@@ -48,11 +52,15 @@ async def update_user_query_limit_data(
     """Updates the query limits and last reset time for a user in Redis."""
     user_key = f"user:{username}"
     if not await db.exists(user_key):
+        logger.warning(
+            f"Attempted to update query limit for non-existent user: {username}"
+        )
         return False  # User not found
     await db.hset(
         user_key,
         mapping={"query_limits": query_limits, "last_query_reset": last_query_reset},
     )
+    logger.info(f"Query limit data updated for user: {username}.")
     return True
 
 
@@ -60,6 +68,10 @@ async def update_user_openai_key(db: Redis, username: str, openai_api_key: str) 
     """Updates the OpenAI API key for a user in Redis."""
     user_key = f"user:{username}"
     if not await db.exists(user_key):
+        logger.warning(
+            f"Attempted to update OpenAI key for non-existent user: {username}"
+        )
         return False  # User not found
     await db.hset(user_key, mapping={"OPENAI_API_KEY": openai_api_key})
+    logger.info(f"OpenAI API key updated for user: {username}.")
     return True

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -48,6 +48,10 @@ class UserQueryLimitUpdate(BaseModel):
     last_query_reset: datetime
 
 
+class UserOpenAIKeyUpdate(BaseModel):
+    OPENAI_API_KEY: str = Field(..., min_length=10)
+
+
 class AdminUserQueryLimitUpdate(BaseModel):
     admin_password: str
     new_query_limit: int

--- a/app/user_routes.py
+++ b/app/user_routes.py
@@ -1,24 +1,24 @@
-from datetime import datetime  # Added for query limit reset
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi_limiter.depends import (
     RateLimiter,  # Corrected import path if necessary, or ensure it's available
 )
-from pydantic import EmailStr  # Added for email validation
+from pydantic import EmailStr
 from redis.asyncio import Redis
 
 from app.crud.user import (
     get_user_by_username,
-    update_user_openai_key,  # Added import
+    update_user_openai_key,
     update_user_query_limit_data,
 )
 from app.models.user import (
     AdminUserQueryLimitUpdate,
-    UserOpenAIKeyUpdate,  # Added import
+    UserOpenAIKeyUpdate,
     UserPublic,
     UserQueryLimitUpdate,
 )
-from app.utils.email_utils import send_welcome_email  # Added import
+from app.utils.email_utils import send_welcome_email
 from app.utils.environment import CONFIG
 from app.utils.redis_utils import get_redis_connection
 from app.utils.security import (


### PR DESCRIPTION
Introduce a new endpoint that allows users to update their OpenAI API key. This includes the necessary logic and data models to handle the update process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint allowing users to update their OpenAI API key.
  - Users can securely update their OpenAI API key from their profile.
  - The new endpoint enforces authentication and rate limiting for added security.
  - Enhanced logging for user-related operations including API key updates and query limit changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->